### PR TITLE
add option to print an environment variable

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,4 +8,9 @@ var dotenv = require('dotenv')
 
 dotenv.load({path: path.resolve(argv.e || '.env')})
 
+if (argv.p) {
+  console.log(process.env[argv.p])
+  process.exit()
+}
+
 spawn(argv._[0], argv._.slice(1), {stdio: 'inherit'})

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "preferGlobal": true,
   "repository": "caske33/dotenv-cli",
   "scripts": {
-    "lint": "./node_modules/.bin/standard"
+    "lint": "standard"
   }
 }


### PR DESCRIPTION
I'll still need to update the readme, but usage is
```
dotenv -p NODE_ENV
```