### PR TITLE
Use cross-spawn package to fix spawn issues on Windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var spawn = require('child_process').spawn
+var spawn = require('cross-spawn')
 var path = require('path')
 
 var argv = require('minimist')(process.argv.slice(2))

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dotenv": "./cli.js"
   },
   "dependencies": {
+    "cross-spawn": "^4.0.0",
     "dotenv": "^2.0.0",
     "minimist": "^1.1.3"
   },


### PR DESCRIPTION
ENOENT error when using 'npm' as command instead of 'cpm.cmd'.