### PR TITLE
Added child process exit handler to forward its exit code.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -14,3 +14,6 @@ if (argv.p) {
 }
 
 spawn(argv._[0], argv._.slice(1), {stdio: 'inherit'})
+  .on('exit', function (exitCode) {
+    process.exit(exitCode)
+  })


### PR DESCRIPTION
This caught us out when used with `mocha`. Failing tests would not return an erroneous exit code.