### PR TITLE
support multiple env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Another .env file could be specified using the -e flag:
 $ dotenv -e .env2 <command with arguments>
 ```
 
+Multiple .env files can be specified, and will be processed in order:
+```bash
+$ dotenv -e .env3 -e .env4 <command with arguments>
+```
+
 If you want to check the value of an environment variable, use the `-p` argument
 ```bash
 $ dotenv -p NODE_ENV

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,16 @@ var path = require('path')
 var argv = require('minimist')(process.argv.slice(2))
 var dotenv = require('dotenv')
 
-dotenv.load({path: path.resolve(argv.e || '.env')})
+var paths = ['.env']
+if (argv.e) {
+  if (typeof argv.e === 'string')
+    paths = [argv.e]
+  else
+    paths = argv.e
+}
+paths.forEach(function (env) {
+  dotenv.load({path: path.resolve(env)})
+})
 
 if (argv.p) {
   console.log(process.env[argv.p])


### PR DESCRIPTION
Currently, this is possible by having dotenv invoke itself:
```
$ dotenv -e .env1 dotenv -e .env2 <command>
```
This PR simplifies the above by supporting:
```
$ dotenv -e .env1 -e .env2 <command>
```